### PR TITLE
subscribe new user should set status to pending mode

### DIFF
--- a/subscribe.go
+++ b/subscribe.go
@@ -13,7 +13,7 @@ func (c *Client) Subscribe(listID string, email string, mergeFields map[string]i
 	// Make request
 	params := map[string]interface{}{
 		"email_address": email,
-		"status":        status.Subscribed,
+		"status":        status.Pending,
 		"merge_fields":  mergeFields,
 	}
 	resp, err := c.do(


### PR DESCRIPTION
It should be the default otherwise people can subscribe people who don't want to be subscribed, thus making the API more vulnerable.